### PR TITLE
feat:moved the plugin parameters into a separate file

### DIFF
--- a/config/parameters.js
+++ b/config/parameters.js
@@ -1,0 +1,10 @@
+const parameters = {
+  htmlmin: {
+    collapseWhitespace: true,
+    removeComments: true,
+  },
+  autoprefixer: {
+    overrideBrowserslist: ['last 2 versions'],
+    cascade: false,
+  },
+};

--- a/tasks/buildHTML.js
+++ b/tasks/buildHTML.js
@@ -1,11 +1,13 @@
 import { src, dest } from 'gulp';
 import pug from 'gulp-pug';
+import htmlMin from 'gulp-htmlmin';
 import plumber from 'gulp-plumber';
 import notify from 'gulp-notify';
-import htmlMin from 'gulp-htmlmin';
 import size from 'gulp-size';
 
 import paths from '../config/paths.js';
+import parameters from '../config/parameters.js';
+
 import loadData from './loadData.js';
 
 const buildHTML = () => {
@@ -27,12 +29,7 @@ const buildHTML = () => {
       }),
     )
     .pipe(size({ title: 'HTML before compression:' }))
-    .pipe(
-      htmlMin({
-        collapseWhitespace: true,
-        removeComments: true,
-      }),
-    )
+    .pipe(htmlMin(parameters.htmlmin))
     .pipe(size({ title: 'HTML after compression:' }))
     .pipe(dest(paths.html.build));
 };

--- a/tasks/buildSCSS.js
+++ b/tasks/buildSCSS.js
@@ -12,6 +12,8 @@ const sassCompiler = gulpSass(sass);
 
 import paths from '../config/paths.js';
 
+import { parameters } from '../config/parameters.js';
+
 const buildSCSS = () =>
   src(paths.scss.dev)
     .pipe(
@@ -25,7 +27,7 @@ const buildSCSS = () =>
     .pipe(sourcemaps.init())
     .pipe(size({ title: 'CSS before compilation:' }))
     .pipe(sassCompiler().on('error', sassCompiler.logError))
-    .pipe(autoprefixer())
+    .pipe(autoprefixer(parameters.autoprefixer))
     .pipe(size({ title: 'CSS after autoprefixer:' }))
     .pipe(cleanCSS())
     .pipe(size({ title: 'CSS after minification:' }))


### PR DESCRIPTION
## Description
This pull request refactors the Gulp boilerplate setup by moving plugin parameters into a separate configuration file. This change improves the maintainability and readability of the codebase.

## Changes
- Created a new configuration file `config/parameters.js` to store plugin parameters.
- Updated `gulpfile.js` and relevant task files to import and use the parameters from the new configuration file.

## How to Test
1. Execute the `gulp` command to ensure all tasks are loaded correctly and function as expected.
2. Verify that the plugin parameters are correctly applied from the new configuration file.

## Additional Notes
- This update aims to improve the project structure by centralizing plugin parameters, making it easier to manage and update them.
